### PR TITLE
Convert nightly to main

### DIFF
--- a/users/node/citrea-testnet/citrea-testnet-executable.md
+++ b/users/node/citrea-testnet/citrea-testnet-executable.md
@@ -20,7 +20,7 @@ We're hosting our binary in the [Citrea](https://github.com/chainwayxyz/citrea/r
 
 To sync correctly, config & genesis files should be provided correctly. You can download & extract them using the following:
 ```sh
-curl https://raw.githubusercontent.com/chainwayxyz/citrea/nightly/resources/configs/testnet/rollup_config.toml --output rollup_config.toml
+curl https://raw.githubusercontent.com/chainwayxyz/citrea/main/resources/configs/testnet/rollup_config.toml --output rollup_config.toml
 ```
 ```sh
 curl https://static.testnet.citrea.xyz/genesis.tar.gz --output genesis.tar.gz

--- a/users/node/run-a-node.md
+++ b/users/node/run-a-node.md
@@ -11,7 +11,7 @@ Follow instructions to install Docker [here](https://docs.docker.com/engine/inst
 #### Step 2: Run using Docker Compose
 
 ```
-curl https://raw.githubusercontent.com/chainwayxyz/citrea/nightly/docker-compose.yml --output docker-compose.yml
+curl https://raw.githubusercontent.com/chainwayxyz/citrea/refs/heads/main/docker-compose.yml --output docker-compose.yml
 docker-compose -f docker-compose.yml up
 ```
 


### PR DESCRIPTION
We're using nightly branch for regular development, so this is a quick switch of some links to main branch (which is running live)